### PR TITLE
fixed administering privacy changes

### DIFF
--- a/src/views/projects/administration/administer.ejs
+++ b/src/views/projects/administration/administer.ejs
@@ -60,19 +60,19 @@
                                 <input type="radio"
                                        name="privacy"
                                        value="publicStatus"
-                                       ng-checked="'<%=locals.privacy%>' == 'publicStatus'">Public: The project's metadata will be exposed and the project made publicly available, as read-only.
+                                       ng-checked="'<%=locals.privacy%>' == 'public'">Public: The project's metadata will be exposed and the project made publicly available, as read-only.
                                 </input>
                                 <br>
                                 <input type="radio"
                                        name="privacy"
                                        value="privateStatus"
-                                       ng-checked="'<%=locals.privacy%>' == 'privateStatus'">Private: Your project won't have any exposure.
+                                       ng-checked="'<%=locals.privacy%>' == 'private'">Private: Your project won't have any exposure.
                                 </input>
                                 <br>
                                 <input type="radio"
                                        name="privacy"
                                        value="metadataOnlyStatus"
-                                       ng-checked="'<%=locals.privacy%>' == 'metadataOnlyStatus'">Metadata Only: The project's metadata will be exposed, but access to the project will be required to you.
+                                       ng-checked="'<%=locals.privacy%>' == 'metadata'">Metadata Only: The project's metadata will be exposed, but access to the project will be required to you.
                                 </input>
 
                             </div>


### PR DESCRIPTION
Fixes #35 

### Proposed fixes:

Privacy set during new project creation is visible when entering the admin page of the project

### Features:

- [X] includes user-visible changes
