### PR TITLE
Adjusted the query for the descriptor_autocomplete route. It now orde…

### DIFF
--- a/src/models/meta/descriptor.js
+++ b/src/models/meta/descriptor.js
@@ -1152,10 +1152,13 @@ Descriptor.findByLabelOrComment = function (filterValue, maxResults, callback, a
         "   ?uri rdfs:comment ?comment . \n" +
         "   ?uri rdfs:label ?label . \n" +
         "   FILTER NOT EXISTS { ?uri rdf:type owl:Class } \n" + // eliminate classes, as all descriptors are properties
+        "   FILTER EXISTS { ?uri rdfs:comment ?comment } \n" +
+        "   FILTER EXISTS { ?uri rdfs:label ?label } \n" +
         "   FILTER (regex(?label, \"" + filterValue + "\", \"i\") || regex(?comment, \"" + filterValue + "\", \"i\" )). \n" +
         "   FILTER( (str(?label) != \"\") && ( str(?comment) != \"\") ). \n" +
         "   " + filterString +
         " } \n" +
+        "ORDER BY DESC(regex(?label, \"^" + filterValue + "$\", \"i\")) \n" +
         " LIMIT  " + maxResults;
 
     db.connection.executeViaJDBC(


### PR DESCRIPTION
…rsBy for descriptors that have its label value starting and ending with the searched term. For instance searching for "title" now correctly displays dcterms:title in the result

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
