### PR TITLE
Added a missing "done()" inside the try block. Without it the project…

### DIFF
--- a/test/routes/project/public_project/__administer/routes.project.publicProject.__administerTest.js
+++ b/test/routes/project/public_project/__administer/routes.project.publicProject.__administerTest.js
@@ -49,6 +49,7 @@ describe("Administer projects", function (done)
             try
             {
                 should.equal(err, null);
+                done();
             }
             catch (e)
             {


### PR DESCRIPTION
@silvae86  Added a missing "done()" call inside the try block. Without it the project administer tests were not ending and as a consequence was halting the entire test suite