### PR TITLE
Removed the option to restore a project in the "myProjects" page. The…

### DIFF
--- a/src/views/projects/my.ejs
+++ b/src/views/projects/my.ejs
@@ -70,9 +70,6 @@
                                 <li>
                                     <a href="<%=project.uri%>?delete"><i class="fa fa-bomb"></i>&nbsp;&nbsp;Delete</a>
                                 </li>
-                                <li>
-                                    <a href="<%=project.uri%>?delete"><i class="fa fa-refresh"></i>&nbsp;&nbsp;Restore</a>
-                                </li>
                                 <% } %>
 
                             </ul>


### PR DESCRIPTION
… correct way to do that is to import a project previously backed up

Fixes #

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
