### PR TITLE
Working on project import

### DIFF
--- a/conf/deployment_configs.json
+++ b/conf/deployment_configs.json
@@ -123,7 +123,7 @@
         },
         "mySQLDBName": "dendroVagrantDemo",
         "maxUploadSize": 1073741824,
-        "maxProjectSize": 1073741824,
+        "maxProjectSize": 5368709120,
         "maxSimultaneousConnectionsToDb": 1,
         "dbOperationTimeout": 16000,
         "tempFilesDir": "temp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9021,22 +9021,6 @@
         "yargs": "11.0.0"
       },
       "dependencies": {
-        "minimatch": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "recursive-readdir": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
-          "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
-          "requires": {
-            "minimatch": "3.0.3"
-          }
-        },
         "yargs": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",

--- a/public/app/js/controllers/project/import/import_project_controller.js
+++ b/public/app/js/controllers/project/import/import_project_controller.js
@@ -13,6 +13,7 @@ angular.module("dendroApp.controllers")
             "$timeout",
             "uploadsService",
             "windowService",
+            "projectsService",
             "jsonPath",
             function (
                 $scope,
@@ -24,6 +25,7 @@ angular.module("dendroApp.controllers")
                 $timeout,
                 uploadsService,
                 windowService,
+                projectsService,
                 jsonPath
             )
             {
@@ -56,10 +58,26 @@ angular.module("dendroApp.controllers")
                     file.imported_project_handle = imported_project_handle;
                     file.imported_project_title = imported_project_title;
                     file.isAsync = true;
-                    $scope.$broadcast(
-                        "new_files_to_upload",
-                        [file]
-                    );
+
+                    projectsService.get_project_info_by_handle(file.imported_project_handle)
+                        .then(function (response)
+                        {
+                            Utils.show_popup("error", "Project handle already exists!", "Please try another project handle!");
+                        })
+                        .catch(function (error)
+                        {
+                            if(error.status == 404)
+                            {
+                                $scope.$broadcast(
+                                    "new_files_to_upload",
+                                    [file]
+                                );
+                            }
+                            else
+                            {
+                                Utils.show_popup("error", "Error when finding if project handle is unique", JSON.stringify(error));
+                            }
+                        });
                 };
 
                 $scope.init = function ()

--- a/public/app/js/controllers/project/import/import_project_controller.js
+++ b/public/app/js/controllers/project/import/import_project_controller.js
@@ -54,6 +54,7 @@ angular.module("dendroApp.controllers")
                 {
                     file.imported_project_handle = imported_project_handle;
                     file.imported_project_title = imported_project_title;
+                    file.isAsync = true;
                     $scope.$broadcast(
                         "new_files_to_upload",
                         [file]

--- a/public/app/js/controllers/project/import/import_project_controller.js
+++ b/public/app/js/controllers/project/import/import_project_controller.js
@@ -36,7 +36,8 @@ angular.module("dendroApp.controllers")
                     {
                         if (result instanceof Array && result.length === 1)
                         {
-                            window.location = result[0].data.new_project;
+                            //window.location = result[0].data.new_project;
+                            window.location = "/projects/my";
                         }
                     }
                     else

--- a/public/app/js/controllers/project/new_project_controller.js
+++ b/public/app/js/controllers/project/new_project_controller.js
@@ -25,18 +25,27 @@ angular.module("dendroApp.controllers")
 
             $scope.create_project = function (new_project)
             {
-                new_project.language = new_project.language.alpha2;
-                projectsService.create_new_project(new_project)
-                    .then(function (result)
-                    {
-                        var newURL = $scope.get_host() + "/projects/my";
-                        window.location.href = newURL;
-                        $scope.show_popup("success", "Success", "Project created");
-                    })
-                    .catch(function (error)
-                    {
-                        $scope.show_popup("error", "Error", error.message);
-                    });
+                if(!new_project.language || !new_project.language.alpha2)
+                {
+                    Utils.show_popup("error", "Error", "Please set the language!");
+                }
+                else
+                {
+                    new_project.language = new_project.language.alpha2;
+                    projectsService.create_new_project(new_project)
+                        .then(function (result)
+                        {
+                            var newURL = $scope.get_host() + "/projects/my";
+                            window.location.href = newURL;
+                            //$scope.show_popup("success", "Success", "Project created");
+                            Utils.show_popup("success", "Success", "Project created");
+                        })
+                        .catch(function (error)
+                        {
+                            //$scope.show_popup("error", "Error", error.message);
+                            Utils.show_popup("error", "Error", error.message);
+                        });
+                }
             };
 
             $scope.init = function ()

--- a/public/app/js/services/projects_service.js
+++ b/public/app/js/services/projects_service.js
@@ -204,6 +204,16 @@ angular.module("dendroApp.services")
                     });
                 };
 
+                this.get_project_info_by_handle = function (projectHandle) {
+                    var requestUri = "/project/" + projectHandle;
+                    return $http({
+                        method: "GET",
+                        url: requestUri,
+                        contentType: "application/json",
+                        headers: {Accept: "application/json"}
+                    });
+                };
+
                 this.update_project_settings = function (project)
                 {
                     var deferred = $q.defer();

--- a/public/app/js/services/uploads_service.js
+++ b/public/app/js/services/uploads_service.js
@@ -49,7 +49,7 @@ angular.module("dendroApp.services")
                     for (var i = 0; i < keys.length; i++)
                     {
                         var key = keys[i];
-                        if (file.hasOwnProperty(key) && (typeof file[key] === "string"))
+                        if (file.hasOwnProperty(key) && ((typeof file[key] === "string") || typeof file[key] === "boolean"))
                         {
                             url.addSearch(key, file[key]);
                         }

--- a/src/bootup/init/start_server.js
+++ b/src/bootup/init/start_server.js
@@ -5,8 +5,8 @@ const Logger = require(Pathfinder.absPathInSrcFolder("utils/logger.js")).Logger;
 
 const startServer = function (app, server, callback)
 {
-    // 5 min timeout
-    const minutesTimeout = 5;
+    // 20 min timeout
+    const minutesTimeout = 20;
     const timeoutMillisecs = minutesTimeout * 60 * 1000;
 
     app.use(timeout(minutesTimeout + "s"));

--- a/src/controllers/files.js
+++ b/src/controllers/files.js
@@ -14,7 +14,7 @@ const FileSystemPost = require(Pathfinder.absPathInSrcFolder("/models/social/fil
 const Uploader = require(Pathfinder.absPathInSrcFolder("/utils/uploader.js")).Uploader;
 const Elements = require(Pathfinder.absPathInSrcFolder("/models/meta/elements.js")).Elements;
 const Logger = require(Pathfinder.absPathInSrcFolder("utils/logger.js")).Logger;
-const contentDisposition = require('content-disposition');
+const contentDisposition = require("content-disposition");
 
 const async = require("async");
 

--- a/src/controllers/files.js
+++ b/src/controllers/files.js
@@ -443,7 +443,7 @@ exports.serve = function (req, res)
 
                                             res.writeHead(200,
                                                 {
-                                                    "Content-disposition": "filename=\"" + file.nie.title + "\"",
+                                                    "Content-Disposition": contentDisposition(file.nie.title),
                                                     "Content-type": mimeType
                                                 });
 
@@ -693,7 +693,7 @@ exports.get_thumbnail = function (req, res)
 
                                                 res.writeHead(200,
                                                     {
-                                                        "Content-disposition": "filename=\"" + filename + "\"",
+                                                        "Content-Disposition": contentDisposition(filename),
                                                         "Content-type": mimeType
                                                     });
 
@@ -2415,7 +2415,7 @@ exports.serve_static = function (req, res, pathOfIntendedFileRelativeToProjectRo
 
         res.writeHead(statusCode,
             {
-                "Content-disposition": "filename=\"" + filename + "\"",
+                "Content-Disposition": contentDisposition(filename),
                 "Content-type": mimeType
             });
 

--- a/src/controllers/projects.js
+++ b/src/controllers/projects.js
@@ -2139,108 +2139,11 @@ exports.import = function (req, res)
                                         getMetadata(absPathOfUnzippedBagIt, function (descriptors)
                                         {
                                             // by default the project is private on import
-                                            //TODO THIS IS NOW COMMENTED
-                                            /*const newProject = new Project({
-                                                ddr: {
-                                                    is_being_imported: true,
-                                                    handle: req.query.imported_project_handle,
-                                                    privacyStatus: "private"
-                                                },
-                                                dcterms: {
-                                                    creator: req.user.uri,
-                                                    title: req.query.imported_project_title
-                                                }
-                                            });*/
-
                                             newProject.updateDescriptors(descriptors);
 
                                             // all imported projects will use default storage by default.
                                             // later we will add parameters for storage in the import screen
                                             // and projects can be imported directly to any kind of storage
-                                            //TODO THIS IS NOW COMMENTED
-                                            /*const storageConf = new StorageConfig({
-                                                ddr: {
-                                                    hasStorageType: "local",
-                                                    handlesStorageForProject: newProject.uri
-                                                }
-                                            });*/
-
-                                            //TODO THIS IS ALSO NOW COMMENTED
-                                            /*
-                                            storageConf.save(function (err, newStorageConf)
-                                            {
-                                                if (isNull(err))
-                                                {
-                                                    newProject.ddr.hasStorageConfig = newStorageConf.uri;
-                                                    Project.createAndInsertFromObject(newProject, function (err, newProject)
-                                                    {
-                                                        if (isNull(err))
-                                                        {
-                                                            newProject.restoreFromFolder(absPathOfDataRootFolder, req.user, true, true, function (err, result)
-                                                            {
-                                                                if (isNull(err))
-                                                                {
-                                                                    delete newProject.ddr.is_being_imported;
-                                                                    newProject.save(function (err, result)
-                                                                    {
-                                                                        if (isNull(err))
-                                                                        {
-                                                                            callback(null,
-                                                                                {
-                                                                                    result: "ok",
-                                                                                    message: "Project imported successfully.",
-                                                                                    new_project: newProject.uri
-                                                                                }
-                                                                            );
-                                                                        }
-                                                                        else
-                                                                        {
-                                                                            callback(500,
-                                                                                {
-                                                                                    result: "error",
-                                                                                    message: "Error marking project restore as complete.",
-                                                                                    error: result
-                                                                                }
-                                                                            );
-                                                                        }
-                                                                    });
-                                                                }
-                                                                else
-                                                                {
-                                                                    callback(500,
-                                                                        {
-                                                                            result: "error",
-                                                                            message: "Error restoring project contents from unzipped backup folder",
-                                                                            error: result
-                                                                        }
-                                                                    );
-                                                                }
-                                                            });
-                                                        }
-                                                        else
-                                                        {
-                                                            callback(500,
-                                                                {
-                                                                    result: "error",
-                                                                    message: "Error creating new project record before import operation could start",
-                                                                    error: result
-                                                                }
-                                                            );
-                                                        }
-                                                    });
-                                                }
-                                                else
-                                                {
-                                                    callback(500,
-                                                        {
-                                                            result: "error",
-                                                            message: "Unable to create new local storage configuration when importing a new project.",
-                                                            error: newStorageConf
-                                                        }
-                                                    );
-                                                }
-                                            });*/
-
                                             Project.createAndInsertFromObject(newProject, function (err, newProject)
                                             {
                                                 if (isNull(err))

--- a/src/controllers/projects.js
+++ b/src/controllers/projects.js
@@ -22,6 +22,7 @@ const Logger = require(Pathfinder.absPathInSrcFolder("utils/logger.js")).Logger;
 const nodemailer = require("nodemailer");
 const flash = require("connect-flash");
 const async = require("async");
+const contentDisposition = require('content-disposition');
 
 exports.all = function (req, res)
 {
@@ -1492,7 +1493,7 @@ exports.bagit = function (req, res)
 
                             res.writeHead(200,
                                 {
-                                    "Content-disposition": "filename=\"Project " + project.dcterms.title + " (Backup at " + new Date().toISOString() + ").zip" + "\"",
+                                    "Content-disposition": contentDisposition("Project " + project.dcterms.title + " (Backup at " + new Date().toISOString() + ").zip"),
                                     "Content-type": Config.mimeType("zip")
                                 });
 

--- a/src/controllers/projects.js
+++ b/src/controllers/projects.js
@@ -22,7 +22,7 @@ const Logger = require(Pathfinder.absPathInSrcFolder("utils/logger.js")).Logger;
 const nodemailer = require("nodemailer");
 const flash = require("connect-flash");
 const async = require("async");
-const contentDisposition = require('content-disposition');
+const contentDisposition = require("content-disposition");
 
 exports.all = function (req, res)
 {
@@ -1970,7 +1970,7 @@ exports.import = function (req, res)
                                         }
                                         else
                                         {
-                                            callback(err, nProject)
+                                            callback(err, nProject);
                                         }
                                     }
                                     else

--- a/src/controllers/records.js
+++ b/src/controllers/records.js
@@ -12,7 +12,7 @@ const File = require(Pathfinder.absPathInSrcFolder("/models/directory_structure/
 const Descriptor = require(Pathfinder.absPathInSrcFolder("/models/meta/descriptor.js")).Descriptor;
 const MetadataChangePost = require(Pathfinder.absPathInSrcFolder("/models/social/metadataChangePost.js")).MetadataChangePost;
 const async = require("async");
-const contentDisposition = require('content-disposition');
+const contentDisposition = require("content-disposition");
 const db_social = Config.getDBByID("social");
 
 exports.show_deep = function (req, res)

--- a/src/controllers/records.js
+++ b/src/controllers/records.js
@@ -12,6 +12,7 @@ const File = require(Pathfinder.absPathInSrcFolder("/models/directory_structure/
 const Descriptor = require(Pathfinder.absPathInSrcFolder("/models/meta/descriptor.js")).Descriptor;
 const MetadataChangePost = require(Pathfinder.absPathInSrcFolder("/models/social/metadataChangePost.js")).MetadataChangePost;
 const async = require("async");
+const contentDisposition = require('content-disposition');
 const db_social = Config.getDBByID("social");
 
 exports.show_deep = function (req, res)
@@ -59,7 +60,7 @@ exports.show_deep = function (req, res)
                                 result.data_processing_error = resource.ddr.hasDataProcessingError;
 
                                 res.set("Content-Type", contentType);
-                                res.set("Content-disposition", "attachment; filename=\"" + resource.nie.title + "\"");
+                                res.set("Content-disposition", contentDisposition(resource.nie.title));
                                 res.send(serializer(result));
                             }
                             else
@@ -144,8 +145,7 @@ exports.show = function (req, res)
                                 result.is_a_file = requestedResource.isA(File);
 
                                 res.set("Content-Type", contentType);
-                                res.set("Content-disposition", "attachment; filename=\"" + requestedResource.nie.title + "\"");
-
+                                res.set("Content-disposition", contentDisposition(requestedResource.nie.title));
                                 res.send(serializer(result));
                             }
                             else

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -9,7 +9,7 @@ const Descriptor = require(Pathfinder.absPathInSrcFolder("/models/meta/descripto
 const DbConnection = require(Pathfinder.absPathInSrcFolder("/kb/db.js")).DbConnection;
 const Elements = require(Pathfinder.absPathInSrcFolder("/models/meta/elements.js")).Elements;
 const Logger = require(Pathfinder.absPathInSrcFolder("utils/logger.js")).Logger;
-const contentDisposition = require('content-disposition');
+const contentDisposition = require("content-disposition");
 
 const async = require("async");
 const fs = require("fs");

--- a/src/models/meta/elements.js
+++ b/src/models/meta/elements.js
@@ -798,6 +798,12 @@ Elements.ontologies.foaf =
  */
 
 Elements.ontologies.ddr = {
+    hasErrors:
+        {
+            type: Elements.types.string,
+            control: Controls.input_box,
+            api_readable: true
+        },
     hasStorageConfig:
         {
             type: Elements.types.string,

--- a/src/models/project.js
+++ b/src/models/project.js
@@ -1563,7 +1563,7 @@ Project.unzipAndValidateBagItBackupStructure = function (absPathToZipFile, maxSt
             if (!isNaN(size))
             {
                 // admin is god, can import as much data as (s)he wants
-                if (size < maxStorageSize || req.user.isAdmin)
+                if (size < maxStorageSize || req.user.isAdmin || req.session.isAdmin)
                 {
                     File.unzip(absPathToZipFile, function (err, absPathOfRootFolder)
                     {
@@ -1599,7 +1599,7 @@ Project.unzipAndValidateBagItBackupStructure = function (absPathToZipFile, maxSt
                     const humanMaxStorageSize = filesize(maxStorageSize).human("jedec");
 
                     const msg = "Estimated storage size of the project after unzipping ( " + humanZipFileSize + " ) exceeds the maximum storage allowed for a project ( " + humanMaxStorageSize + " ) by " + humanSizeDifference;
-                    return callback(err, msg);
+                    return callback(true, msg);
                 }
             }
             else

--- a/src/views/layout/includes.ejs
+++ b/src/views/layout/includes.ejs
@@ -12,7 +12,7 @@
 <link rel='stylesheet' type="text/css" href='/stylesheets/uploads.css' />
 <link rel="stylesheet" type="text/css" href="/bower_components/font-awesome/css/font-awesome.min.css">
 <link rel="stylesheet" type="text/css" href="/bower_components/font-awesome-animation/dist/font-awesome-animation.min.css">
-<link rel="stylesheet" type="text/cses" href="/bower_components/pnotify/dist/pnotify.css"/>
+<link rel="stylesheet" type="text/css" href="/bower_components/pnotify/dist/pnotify.css"/>
 <link rel="stylesheet" type="text/css" href="/bower_components/pnotify/dist/pnotify.buttons.css"/>
 
 <link rel="stylesheet" type="text/css" href="/bower_components/bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" />

--- a/src/views/projects/import/import.ejs
+++ b/src/views/projects/import/import.ejs
@@ -37,7 +37,7 @@
                        placeholder="The handle of the imported project"
                        ng-model="handle"
                        required="">
-                <p class="help-block"><u class="label" ng-class="{ 'label-success': valid_word(handle), 'label-primary': !handle, 'label-danger' : handle && !valid_word(handle)}">Only lower case and numbers.</u> Example: "gravimetry01". This will be a unique identifier for the project that will be created after importing this backup. </p>
+                <p class="help-block"><u class="label" ng-class="{ 'label-success': valid_word(handle), 'label-primary': !handle, 'label-danger' : handle && !valid_word(handle)}">A single word with only lower case and numbers.</u> Example: "gravimetry01". This will be a unique identifier for the project that will be created after importing this backup. </p>
                 <span ng-show="!handle" class="glyphicon glyphicon-remove form-control-feedback"></span>
                 <span ng-show="valid_word(handle) && handle" class="glyphicon glyphicon-ok form-control-feedback"></span>
                 <span ng-show="!valid_word(handle) && handle" class="glyphicon glyphicon-warning-sign form-control-feedback"></span>

--- a/src/views/projects/my.ejs
+++ b/src/views/projects/my.ejs
@@ -46,9 +46,17 @@
                     %>
                     <form>
                         <div class="btn-group">
-                            <button type="submit" class="btn btn-default" onclick="location.href='<%=project.uri%>'">
-                                <img class="icon16" id="upload_button" src="/images/icons/box_closed.png"> <%= (project.dcterms.title)? project.dcterms.title : project.ddr.handle %>
-                            </button>
+                            <%if(!project.ddr.hasErrors && !project.ddr.is_being_imported)
+                            {
+                            %>
+                                <button type="submit" class="btn btn-default" onclick="location.href='<%=project.uri%>'">
+                                    <img class="icon16" id="upload_button" src="/images/icons/box_closed.png"> <%= (project.dcterms.title)? project.dcterms.title : project.ddr.handle %>
+                                </button>
+                            <%} else {%>
+                                <button style='color:red;text-decoration:line-through' type="submit" class="btn btn-default">
+                                    <img class="icon16" id="upload_button" src="/images/icons/box_closed.png"> <%= (project.dcterms.title)? project.dcterms.title : project.ddr.handle %>
+                                </button>
+                            <%}%>
                             <%
                             if(locals.user != null && locals.user.uri == project.dcterms.creator)
                             {
@@ -62,12 +70,29 @@
                                 if(locals.user != null && locals.user.uri == project.dcterms.creator)
                                 {
                                 %>
+                                <%if(!project.ddr.hasErrors && !project.ddr.is_being_imported)
+                                {
+                                %>
                                 <li>
-                                    <a href="<%=project.uri%>?administer"><i class="fa fa-cog"></i>&nbsp;&nbsp;Administer</a>
+                                    <a href="<%=project.uri%>?administer"><i class="fa fa-cog"></i>Administer</a>
                                 </li>
                                 <li>
-                                    <a href="<%=project.uri%>?bagit"><i class="fa fa-file-zip-o"></i>&nbsp;&nbsp;Backup</a>
+                                    <a href="<%=project.uri%>?bagit"><i class="fa fa-file-zip-o"></i>Backup</a>
                                 </li>
+                                <%} else {%>
+                                <li>
+                                    <!--<a href="<%=project.uri%>?administer"><i class="fa fa-cog"></i>&nbsp;&nbsp;Administer</a>-->
+                                    <span style='color:red;text-decoration:line-through'>
+                                        <span style='color:black'><i class="fa fa-cog"></i>Administer</span>
+                                    </span>
+                                </li>
+                                <li>
+                                    <!--<a href="<%=project.uri%>?bagit"><i class="fa fa-file-zip-o"></i>&nbsp;&nbsp;Backup</a>-->
+                                    <span style='color:red;text-decoration:line-through'>
+                                        <span style='color:black'><i class="fa fa-file-zip-o"></i>Backup</span>
+                                    </span>
+                                </li>
+                                <%}%>
                                 <li>
                                     <a href="<%=project.uri%>?delete"><i class="fa fa-bomb"></i>&nbsp;&nbsp;Delete</a>
                                 </li>
@@ -149,17 +174,20 @@
             <td>
                 <%if(project.ddr.is_being_imported) {%>
                 <div>
-                    <span spinner-key="project-being-imported-spinner" us-spinner="{radius:5}"
-                          spinner-start-active="true" style="position: relative"> Restoring</span>
+                    <p><i class="fa fa-spinner fa-pulse"></i>Restoring Project!</p>
                 </div>
                 <%
                 } else if(project.ddr.hasErrors) {
                 %>
-                <p> Errors : <%=project.ddr.hasErrors%> </p>
+                <div>
+                    <p><i class="fa fa-exclamation-triangle"></i>Errors : <%=project.ddr.hasErrors%></p>
+                </div>
                 <%
                 } else {
                 %>
-                <p> Everything good! </p>
+                <div>
+                    <p><i class="fa fa-check-circle"></i>Everything good!</p>
+                </div>
                 <%
                 }
                 %>

--- a/src/views/projects/my.ejs
+++ b/src/views/projects/my.ejs
@@ -20,6 +20,7 @@
             <th>Description</th>
             <th>Creator</th>
             <th>Privacy</th>
+            <th>Status</th>
             <!--<th width="5%"></th>-->
         </tr>
         </thead>
@@ -143,6 +144,25 @@
                         %>
                     </div>
                 </div>
+            </td>
+
+            <td>
+                <%if(project.ddr.is_being_imported) {%>
+                <div>
+                    <span spinner-key="project-being-imported-spinner" us-spinner="{radius:5}"
+                          spinner-start-active="true" style="position: relative"> Restoring</span>
+                </div>
+                <%
+                } else if(project.ddr.hasErrors) {
+                %>
+                <p> Errors : <%=project.ddr.hasErrors%> </p>
+                <%
+                } else {
+                %>
+                <p> Everything good! </p>
+                <%
+                }
+                %>
             </td>
             <!--<td>
                                                     <button type="submit" class="btn btn-default btn-small" onclick="location.href='<%=project.uri%>?recycle_bin'">

--- a/src/views/uploads/file_upload_progress_bar.ejs
+++ b/src/views/uploads/file_upload_progress_bar.ejs
@@ -53,7 +53,8 @@
         </div>
 
         <div class="col-xs-10 col-md-12" ng-show="file.has_error">
-            <small><span><i class="fa fa-exclamation-triangle warning"></i>&nbsp;{{file.has_error.error}}</span></small>
+            <small ng-show="file.has_error.message"><span><i class="fa fa-exclamation-triangle warning"></i>{{file.has_error.message}}</span></small>
+            <small ng-show="file.has_error.error"><span><i class="fa fa-exclamation-triangle warning"></i>{{file.has_error.error}}</span></small>
         </div>
         <div class="col-xs-10 col-md-12" ng-show="file.has_success">
             <small><span><i class="fa fa-check-circle-o success"></i>&nbsp;{{file.has_success}}</span></small>

--- a/test/index.Test.dev.js
+++ b/test/index.Test.dev.js
@@ -17,6 +17,9 @@ global.tests = {};
 // uncomment the first time you run the tests after installing dendro
 require(Pathfinder.absPathInTestsFolder("/init/loadOntologiesCache.Test.js"));
 
+// Import projects tests
+require(Pathfinder.absPathInTestsFolder("/routes/projects/import/route.projects.import.Test.js"));
+
 // list orphan resources tests /admin/list_orphan_resources
 require(Pathfinder.absPathInTestsFolder("/routes/admin/list_orphan_resources/routes.admin.listOrphanResources.Test.js"));
 
@@ -124,9 +127,6 @@ require(Pathfinder.absPathInTestsFolder("/routes/project/metadata_only_project/d
 
 // Archived versions test
 require(Pathfinder.absPathInTestsFolder("/routes/archived_resource/routes.archivedResource.Test.js"));
-
-// Import projects tests
-require(Pathfinder.absPathInTestsFolder("/routes/projects/import/route.projects.import.Test.js"));
 
 // Dendro Administration page
 require(Pathfinder.absPathInTestsFolder("/routes/admin/routes.admin.Test.js"));

--- a/test/index.Test.dev.js
+++ b/test/index.Test.dev.js
@@ -17,6 +17,17 @@ global.tests = {};
 // uncomment the first time you run the tests after installing dendro
 require(Pathfinder.absPathInTestsFolder("/init/loadOntologiesCache.Test.js"));
 
+// PROJECT WITH B2DROP STORAGE
+require(Pathfinder.absPathInTestsFolder("/routes/project/b2drop_project/data/testFolder1/__upload/routes.project.b2dropProject.data.testFolder1.__upload.Test.js"));
+require(Pathfinder.absPathInTestsFolder("/routes/project/b2drop_project/data/testFolder1/a_filename/__rename/routes.project.b2dropProject.data.testFolder1.a_filename.__rename.Test.js"));
+require(Pathfinder.absPathInTestsFolder("/routes/project/b2drop_project/data/testFolder1/a_filename/__cut/routes.project.b2dropProject.data.testFolder1.a_filename.__cut.Test.js"));
+require(Pathfinder.absPathInTestsFolder("/routes/project/b2drop_project/__bagit/routes.project.b2dropProject.__bagit.Test.js"));
+require(Pathfinder.absPathInTestsFolder("/routes/project/b2drop_project/__delete/routes.project.b2dropProject.__delete.Test.js"));
+
+// PROJECT WITH LOCAL STORAGE
+// test file uploads
+require(Pathfinder.absPathInTestsFolder("/routes/project/private_project/data/testFolder1/__upload/routes.project.privateProject.data.testFolder1.__upload.Test.js"));
+
 // Import projects tests
 require(Pathfinder.absPathInTestsFolder("/routes/projects/import/route.projects.import.Test.js"));
 

--- a/test/routes/projects/import/route.projects.import.Test.js
+++ b/test/routes/projects/import/route.projects.import.Test.js
@@ -232,12 +232,32 @@ describe("Import projects", function (done)
 
     describe("[POST] [Valid Cases] /projects/import", function ()
     {
+
+        // The controller function for the import of projects has changed
+        // The dendro webapp now responds to the client right after the project zip is uploaded
+        // If there are any errors after the zip upload stage-> they are show on the projects list page
+        // The user then has to delete the project or try again
+        // This was necessary because some projects being imported were so large that timeouts were occurring
+        // So if there are any errors post upload of the zip file -> the project is now not deleted automatically -> the user is shown a status with an error and error message in the projects list page
+        // this "before" call bellow is needed because in the previous "describe"
+        //In the stub "Should give an error with a status code of 500 when the zip file used to import the project is not in a correct BagIt Format, even though the user is logged in"
+        //The import fails but the error given occurs after the project is already created
+        //So the project privateproject is leftover with an errored stated
+        //This is why this "before" call is needed
+        before(function (done)
+        {
+            createUsersUnit.setup(function (err, results)
+            {
+                should.equal(err, null);
+                done();
+            });
+        });
+
         it("Should import all projects correctly when the user is logged in and the zip file used to import the project is not corrupted", function (done)
         {
             userUtils.loginUser(demouser1.username, demouser1.password, function (err, agent)
             {
                 should.equal(err, null);
-
                 async.mapSeries(projectsData, function (projectData, callback)
                 {
                     projectUtils.importProject(true, agent, projectData, function (err, res)


### PR DESCRIPTION
Fixes #341 

Fixed Dendro handling of files with certain characters -> was crashing Dendro when these files were downloaded or even selected.

Fixed the show_popup utility -> was due to a bad import of a css file

Imports of projects now respond to the client right after the zip file is uploaded to Dendro, the rest of the process happens in the background, users can see the status of the project in the projects listing page. Navigating into the project is blocked while the restore process is not yet completed.

### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
